### PR TITLE
Remove duplicate dependencies on rdoc

### DIFF
--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -142,18 +142,15 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, [">= 2.4.2"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<rdoc>, [">= 2.4.2"])
     else
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rdoc>, [">= 2.4.2"])
       s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<rdoc>, [">= 2.4.2"])
     end
   else
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rdoc>, [">= 2.4.2"])
     s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<rdoc>, [">= 2.4.2"])
   end
 end
 


### PR DESCRIPTION
These duplicate lines were causing this warning when installing the gem with Bundler:

> holidays at /path/to/bundler/gems/holidays-542fe5e61542 did not have a valid gemspec.
> This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
> The validation message from Rubygems was:
>   duplicate dependency on rdoc (>= 2.4.2, development), (>= 2.4.2) use:
>     add_runtime_dependency 'rdoc', '>= 2.4.2', '>= 2.4.2'
